### PR TITLE
API Proposal - Connect to the Clarius probe without user interaction

### DIFF
--- a/mobileapi/src/main/java/me/clarius/mobileapi/MobileApi.java
+++ b/mobileapi/src/main/java/me/clarius/mobileapi/MobileApi.java
@@ -214,7 +214,8 @@ public class MobileApi
     //! The event MSG_PROBE_STATUS_CHANGED will inform you whether the connection has succeeded.
     //!
     //! Parameter(s):
-    //! - Bundle[KEY_SELECTED_PROBE]: String, the serial number of the probe to connect to
+    //! - Bundle[KEY_SELECT_PROBE]: String, the serial number of the probe to connect to
+    //! - Bundle[KEY_SELECT_APPLICATION]: String, the name of the application to use for the scanner, i.e. vascular. A list of available applications is defined here: TODO
     //! - Message.replyTo (optional): if set, Messenger to send the MSG_RETURN_STATUS message to.
     //! - Message.arg1 (optional): callback parameter for MSG_RETURN_STATUS.
     //!
@@ -457,7 +458,8 @@ public class MobileApi
     public static final String KEY_CAPTURE_ID = "captureID";
     public static final String KEY_FILE_NAME = "fileName";
     public static final String KEY_SIZE_BYTES = "sizeBytes";
-    public static final String KEY_SELECTED_PROBE = "selectedProbe";
+    public static final String KEY_SELECT_PROBE = "selectProbe";
+    public static final String KEY_SELECT_APPLICATION = "selectApplication";
     public static final String KEY_PROBES = "listProbes";
 
     // Predefined bundle values

--- a/mobileapi/src/main/java/me/clarius/mobileapi/MobileApi.java
+++ b/mobileapi/src/main/java/me/clarius/mobileapi/MobileApi.java
@@ -200,6 +200,7 @@ public class MobileApi
     //! - Message.replyTo: client's Messenger where the reply should be sent. This field is mandatory; if missing, the query will be ignored.
     //! - Message.arg1 (optional): callback parameter for MSG_RETURN_PROBES.
     //!
+    //! MSG_RETURN_STATUS Message.arg2 will be 0 if the request failed, i.e. the Clarius user is not logged in and the available probes cannot be retrieved.
     //! \version Added in version x.x.x
 
     public static final int MSG_LIST_PROBES = 18;

--- a/mobileapi/src/main/java/me/clarius/mobileapi/MobileApi.java
+++ b/mobileapi/src/main/java/me/clarius/mobileapi/MobileApi.java
@@ -192,6 +192,35 @@ public class MobileApi
 
     public static final int MSG_COPY_RAW_DATA = 17;
 
+    //! Query the service with all available ultrasound probes and their connection status.
+    //!
+    //! The reply will be delived with the MSG_RETURN_PROBES.
+    //!
+    //! Parameters(s):
+    //! - Message.replyTo: client's Messenger where the reply should be sent. This field is mandatory; if missing, the query will be ignored.
+    //! - Message.arg1 (optional): callback parameter for MSG_RETURN_PROBES.
+    //!
+    //! \version Added in version x.x.x
+
+    public static final int MSG_LIST_PROBES = 18;
+
+    //! Select a scanner and try to connect to it. Follows the same behaviour as the "Select Scanner" UI element in the Clarius app. Tries to connect to the probes wifi automatically. Follows the connection setup as configured in the Clarius app, i.e. direct Wifi or pre-configured custom SSID.
+    //!
+    //! The MSG_RETURN_STATUS will be
+    //! - 0 if the scanner or scan application does not exist, if the license for the mobile API cannot be used or for any other reason the request for connection cannot be executed.
+    //! - 1 if the request was successful. This does not mean that the probe has been successfully connected. For this, listen to the MSG_PROBE_STATUS_CHANGED
+    //!
+    //! The event MSG_PROBE_STATUS_CHANGED will inform you whether the connection has succeeded.
+    //!
+    //! Parameter(s):
+    //! - Bundle[KEY_SELECTED_PROBE]: String, the serial number of the probe to connect to
+    //! - Message.replyTo (optional): if set, Messenger to send the MSG_RETURN_STATUS message to.
+    //! - Message.arg1 (optional): callback parameter for MSG_RETURN_STATUS.
+    //!
+    //! \version Added in version x.x.x
+
+    public static final int MSG_SELECT_PROBE = 19;
+
     // Messages from server to client.
 
     //! Return the outcome of a command sent by the client.
@@ -376,6 +405,28 @@ public class MobileApi
 
     public static final int MSG_RAW_DATA_COPIED = 123;
 
+    //! Reply to query MSG_LIST_PROBES
+    //!
+    //! Parameters:
+    //! - Bundle[KEY_PROBES]: me.clarius.mobileapi.Probes, a list of probes that are available to the current Clarius user
+    //! - Message.arg1: callback parameter copied from the Message.arg1 sent by the client.
+    //!
+    //! \version Added in version x.x.x
+
+    public static final int MSG_RETURN_PROBES = 124;
+
+    //! Server event for the current probe connection status
+    //!
+    //! Parameters:
+    //! - Message.arg1: int
+    //!    0 - a previously successfully connected probe disconnected or a connection attempt failed
+    //!    1 - probe connected successfully and is ready for imaging (bluetooth + wifi available)
+    //!
+    //! If a connection attempt failed (i.e status 0) the MSG_SELECT_PROBE needs to be initiated again. The MobileAPI does not retry a failed attempt for you.
+    //!
+    //! \version Added in version x.x.x
+    public static final int MSG_PROBE_STATUS_CHANGED = 125;
+
     // Bundle keys
 
     public static final String KEY_IMAGE_SIZE = "size";
@@ -405,6 +456,8 @@ public class MobileApi
     public static final String KEY_CAPTURE_ID = "captureID";
     public static final String KEY_FILE_NAME = "fileName";
     public static final String KEY_SIZE_BYTES = "sizeBytes";
+    public static final String KEY_SELECTED_PROBE = "selectedProbe";
+    public static final String KEY_PROBES = "listProbes";
 
     // Predefined bundle values
 

--- a/mobileapi/src/main/java/me/clarius/mobileapi/ProbeInfo.java
+++ b/mobileapi/src/main/java/me/clarius/mobileapi/ProbeInfo.java
@@ -58,12 +58,7 @@ public class ProbeInfo implements Parcelable
         serial = in.readString();
         model = in.readString();
 	// Added in version x.x.x:
-	try {
-	    name = in.readString();
-	} catch (Exception e) {
-	    // TODO(sven): Check if actual exception occcurs
-	    // NOTE(sven): Read if available, don't crash for backwards compatibility
-	}
+	name = in.readString();
     }
 
     @Override

--- a/mobileapi/src/main/java/me/clarius/mobileapi/ProbeInfo.java
+++ b/mobileapi/src/main/java/me/clarius/mobileapi/ProbeInfo.java
@@ -9,6 +9,7 @@ public class ProbeInfo implements Parcelable
 {
     public String model;        //!< model type
     public String serial;       //!< serial #
+    public String name;         //!< nick name of the scanner, added in version x.x.x
     public int battery;         //!< battery percentage
     public int temperature;     //!< temperature percentage (of max)
     public int version;         //!< version (1 = Clarius 1st Generation, 2 = Clarius HD)
@@ -22,7 +23,8 @@ public class ProbeInfo implements Parcelable
     {
         model = "";
         serial = "";
-        battery = 0;
+        name = "";
+	battery = 0;
         temperature = 0;
         version = 0;
         elements = 0;
@@ -55,6 +57,13 @@ public class ProbeInfo implements Parcelable
         battery = in.readInt();
         serial = in.readString();
         model = in.readString();
+	// Added in version x.x.x:
+	try {
+	    name = in.readString();
+	} catch (Exception e) {
+	    // TODO(sven): Check if actual exception occcurs
+	    // NOTE(sven): Read if available, don't crash for backwards compatibility
+	}
     }
 
     @Override
@@ -69,6 +78,8 @@ public class ProbeInfo implements Parcelable
         out.writeInt(battery);
         out.writeString(serial);
         out.writeString(model);
+	// Added in version x.x.x:
+        out.writeString(name);
     }
 
     @Override

--- a/mobileapi/src/main/java/me/clarius/mobileapi/Probes.java
+++ b/mobileapi/src/main/java/me/clarius/mobileapi/Probes.java
@@ -62,7 +62,7 @@ public class Probe implements Parcelable
 
 public class Probes implements Parcelable
 {
-    public Probes[] probes;
+    public Probe[] probes;
 
     //! Default constructor sets everything to zero.
     //! Note: required for JNI for Android 8 API 26.

--- a/mobileapi/src/main/java/me/clarius/mobileapi/Probes.java
+++ b/mobileapi/src/main/java/me/clarius/mobileapi/Probes.java
@@ -1,0 +1,104 @@
+package me.clarius.mobileapi;
+
+import android.os.Parcel;
+import android.os.Parcelable;
+
+//! A list of available ultrasound scanners for the current Clarius user
+
+// NOTE(sven): This could also be done by reusing the ProbeInfo Parcelable and
+// we would just add some fields.
+public class Probe implements Parcelable
+{
+    public String model;        //!< model type
+    public String serial;       //!< serial
+    public String name;         //!< nick name of the scanner
+    public int version;         //!< version (1 = Clarius 1st Generation, 2 = Clarius HD)
+    public int battery;         //!< battery percentage, 0 if scanner is not available
+    public boolean isAvailable; //!< true, if the scanner is ready to connect
+    public boolean isConnected; //!< true, if the scanner is connected and ready for imaging
+
+    // Parcelable interface
+
+    public static final Parcelable.Creator<Probe> CREATOR = new Parcelable.Creator<Probe>()
+    {
+        public Prob createFromParcel(Parcel in)
+        {
+            return new Probe(in);
+        }
+        public Probe[] newArray(int size)
+        {
+            return new Probe[size];
+        }
+    };
+
+    private Probe(Parcel in)
+    {
+        version = in.readInt();
+        temperature = in.readInt();
+        battery = in.readInt();
+        serial = in.readString();
+        model = in.readString();
+	name = in.readString();
+    }
+
+    @Override
+    public void writeToParcel(Parcel out, int flags)
+    {
+        out.writeInt(version);
+        out.writeInt(temperature);
+        out.writeInt(battery);
+        out.writeString(serial);
+        out.writeString(model);
+	out.writeString(name);
+    }
+
+    @Override
+    public int describeContents()
+    {
+        return 0;
+    }
+}
+
+public class Probes implements Parcelable
+{
+    public Probes[] probes;
+
+    //! Default constructor sets everything to zero.
+    //! Note: required for JNI for Android 8 API 26.
+    public ProbeInfo()
+    {
+        probes = null
+    }
+
+    // Parcelable interface
+
+    public static final Parcelable.Creator<Probes> CREATOR = new Parcelable.Creator<Probes>()
+    {
+        public Probes createFromParcel(Parcel in)
+        {
+            return new Probes(in);
+        }
+
+        public Probes[] newArray(int size)
+        {
+            return new Probes[size];
+        }
+    };
+
+    private Probes(Parcel in)
+    {
+        probes = in.createTypedArray(Probe.CREATOR);
+    }
+
+    @Override
+    public void writeToParcel(Parcel out, int flags)
+    {
+        out.writeTypedArray(probes, 0);
+    }
+
+    @Override
+    public int describeContents()
+    {
+        return 0;
+    }
+}

--- a/mobileapi/src/main/java/me/clarius/mobileapi/Probes.java
+++ b/mobileapi/src/main/java/me/clarius/mobileapi/Probes.java
@@ -14,6 +14,7 @@ public class Probe implements Parcelable
     public String name;         //!< nick name of the scanner
     public int version;         //!< version (1 = Clarius 1st Generation, 2 = Clarius HD)
     public int battery;         //!< battery percentage, 0 if scanner is not available
+    public boolean isVirtual;    //!< true, if the scanner is a virtual demo scanner
     public boolean isAvailable; //!< true, if the scanner is ready to connect
     public boolean isConnected; //!< true, if the scanner is connected and ready for imaging
 
@@ -65,7 +66,7 @@ public class Probes implements Parcelable
 
     //! Default constructor sets everything to zero.
     //! Note: required for JNI for Android 8 API 26.
-    public ProbeInfo()
+    public Probe()
     {
         probes = null
     }

--- a/mobileapi/src/main/java/me/clarius/mobileapi/Probes.java
+++ b/mobileapi/src/main/java/me/clarius/mobileapi/Probes.java
@@ -66,7 +66,7 @@ public class Probes implements Parcelable
 
     //! Default constructor sets everything to zero.
     //! Note: required for JNI for Android 8 API 26.
-    public Probe()
+    public Probes()
     {
         probes = null
     }


### PR DESCRIPTION
**Summary**

This draft proposes new client commands and server events to allow an API user to connect to the Clarius probe, without the user having to open the Clarius app explicitly. In summary, it would allow a 3rd party app to implement the scanner selection dropdown itself.

**Rationale**

This is important to lower any friction for existing Clarius and/ or ThinkSono users for adoption. A user does not expect to have to switch to the Clarius app and manually need to start a scan to enable imaging in a 3rd party app. This lead to user frustration in our testing. Even though there is the 3rd party integration option via `MSG_3P_PACKAGE`, the task for the user is not entirely clear without manual explanation. Also, in situations where the connection to the probe is dropped, manual intervention by the user is required. Ideally, a 3rd party app could attempt to reconnect to the probe automatically. 

We believe that this change can greatly enhance the UX of any user who want to try 3rd party application with the Clarius scanner. 

**Proposal**

The code diff shows the proposal of API specification. The text below gives more context on the envisioned functionality.

1. Listing available probes: 

The API should allow to manually query a list of available probes for the currently logged in Clarius user (`MSG_LIST_PROBES`). A return event will deliver a parcelable with the probe information (`MSG_RETURN_PROBES`). In this draft, I designed it as a list of a new `Probe` class, provided in the return bundle. Alternatively, we could reuse the existing `ProbeInfo` parcelable. For each probe, we want to know all data points to potentially reimplement the scanner selection dropdown, i.e:
* name
* model
* serial
* availability for connection
* connection status 

The `MSG_RETURN_STATUS` can be used to check if the request succeeded, i.e. if the user is not logged in, the list request should fail with status `0`.

2. Selecting a probe / establishing a connection

The API should allow to explicitly connect to an available scanner with a client command (`MSG_SELECT_PROBE`). The probe is selected by providing the serial number and the application name (i.e. `vascular`). The request to connect to the probe may fail, i.e. when trying to connect to a probe that is not available or no license is granted or the application for the selected probe does not exist or the application for a virtual scanner is not downloaded. The `MSG_RETURN_STATUS` returns `0` in that case. 

In order to check whether the probe is actually available for connection an explicit `MSG_PROBE_STATUS_CHANGED` server event is introduced with the following states:
* 0 - a previously successfully connected probe disconnected or a connection attempt failed
* 1 - probe connected successfully and is ready for imaging (bluetooth + wifi available)

If a connection attempt failed (i.e `MSG_RETURN_STATUS` 0) the `MSG_SELECT_PROBE` needs to be initiated again. The MobileAPI does not retry a failed attempt automatically.

-------------

This draft does not support to query available applications for each scanner. This may be solvable by providing a specification, i.e. which set of applications is supported for which scanner/ model/ version combination. Otherwise, the list of available applications could also be returned as part of the `MSG_RETURN_PROBES` server event.

As a side note: The `MSG_LICENSE_CHANGED` event cannot be used to distinguish whether a probe is not properly connected vs the probe has no mobile API license. We currently use this event to indicate to the user that the mobile api has to be enabled in the first place, though we cannot deliver a consistent UX due to this behaviour. The possibility of a `MSG_PROBE_STATUS_CHANGED` would allow for a more explicit interface and resolve those challenges as well.